### PR TITLE
bringing in real SB data

### DIFF
--- a/scripts/fetch/getData_siteRecords.R
+++ b/scripts/fetch/getData_siteRecords.R
@@ -85,5 +85,5 @@ incomplete_lat_lon <- left_join(allIncompleteDF, allDF_oneLineSite, by = "site_n
 
 fwrite(incomplete_lat_lon, file = "incomplete_lat_lon_355.csv")
 allSites_355 <- bind_rows(longOK_join, incomplete_lat_lon)
-fwrite(allSites_355, file = "allSitesYears_355.csv")
+fwrite(allSites_355, file = "allSitesYears_355.csv", quote = TRUE)
 

--- a/scripts/process/process_map.R
+++ b/scripts/process/process_map.R
@@ -58,9 +58,11 @@ process.site_map <- function(viz){
   sites <- readData(viz[['depends']]) 
   huc.map <- c(AK = "19", HI = "20", PR = "21")
   
-  
   library(dplyr)
-  sites.out <- sites %>% filter(!huc %in% huc.map) %>% 
+  #parse huc_cd to 2 digits, and rename to huc to stay consistent
+  sites <- sites %>% rename(huc = huc_cd) %>% mutate(huc = substr(huc, 1,2))
+ 
+  sites.out <- sites %>% filter(!huc %in% huc.map) %>% filter(!is.na(dec_lat_va)) %>% 
     points_sp()
   
   for (region in names(huc.map)){

--- a/scripts/process/process_map.R
+++ b/scripts/process/process_map.R
@@ -55,14 +55,14 @@ process.state_map <- function(viz){
 }
 
 process.site_map <- function(viz){
-  sites <- readData(viz[['depends']]) 
+  library(dplyr)
+  sites <- readData(viz[['depends']]) %>% filter(!is.na(dec_lat_va))
   huc.map <- c(AK = "19", HI = "20", PR = "21")
   
-  library(dplyr)
   #parse huc_cd to 2 digits, and rename to huc to stay consistent
-  sites <- sites %>% rename(huc = huc_cd) %>% mutate(huc = substr(huc, 1,2))
+  sites <- sites %>% rename(huc = huc_cd) %>% mutate(huc = substr(huc, 1,2)) 
  
-  sites.out <- sites %>% filter(!huc %in% huc.map) %>% filter(!is.na(dec_lat_va)) %>% 
+  sites.out <- sites %>% filter(!huc %in% huc.map) %>% 
     points_sp()
   
   for (region in names(huc.map)){

--- a/viz.yaml
+++ b/viz.yaml
@@ -49,11 +49,14 @@ fetch:
     scripts: scripts/fetch/dv_data.R
   -
     id: disch-sites
-    location: cache/disch-sites.rds
-    fetcher: disch_sites
-    refetch: FALSE
-    reader: rds
-    scripts: scripts/fetch/disch_sites.R
+    location: cache/allSitesYears.csv
+    fetcher: sciencebase
+    refetch: false
+    scripts:
+    remoteItemId: 58c1c297e4b014cc3a3d3aa4 
+    remoteFilename: allSitesYears_355.csv 
+    mimetype: text/csv
+    
 process:
   -
     id: state-map


### PR DESCRIPTION
build is crashing in `visualize.states_svg`, as there are 63 more site-years than circles.  Kinda stuck on this.  @jread-usgs or others have any thoughts?