### PR TITLE
fix for duplicated rows

### DIFF
--- a/scripts/process/disch_sites.R
+++ b/scripts/process/disch_sites.R
@@ -3,7 +3,7 @@
 #'@param viz the vizlab object 
 process.disch_sites <- function(viz){
   data.in <- readDepends(viz)
-  browser()
+  
   library(dplyr)
   sites <- data.in[['disch-data']] %>% group_by(site_no) %>% 
     summarize(huc = stringr::str_sub(unique(huc_cd), 1L, 2L), 

--- a/scripts/process/process_bar_chart.R
+++ b/scripts/process/process_bar_chart.R
@@ -3,7 +3,9 @@ process.bar_chart <- function(viz){
   size <- size_map_svg(data.in[['state-map']])
   sites <- data.in$`disch-data`
   library(dplyr)
+  browser()
   bars <- filter(sites, year >= viz[['min-year']], year <= viz[['max-year']]) %>% 
+    select(site_no, year) %>% distinct %>% 
     group_by(year) %>% tally %>% data.frame
   
   max.sites <- max(bars$n)

--- a/scripts/process/process_bar_chart.R
+++ b/scripts/process/process_bar_chart.R
@@ -3,7 +3,7 @@ process.bar_chart <- function(viz){
   size <- size_map_svg(data.in[['state-map']])
   sites <- data.in$`disch-data`
   library(dplyr)
-  browser()
+  
   bars <- filter(sites, year >= viz[['min-year']], year <= viz[['max-year']]) %>% 
     select(site_no, year) %>% distinct %>% 
     group_by(year) %>% tally %>% data.frame


### PR DESCRIPTION
number of rows after the year filter goes from 575972 rows to 558717, which then propagates to different bar counts in the bar plot