### PR TITLE
delete publish date so it doesn't show on dev or prod landing page

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -3,7 +3,7 @@ info:
   id: gages-through-ages
   name: Stream Gages Through the Ages
   date: 2017-03-08
-  publish-date: 9999-01-01
+  publish-date: 
   path: /gages-through-ages
   analytics-id: UA-78530187-1
   description: >-


### PR DESCRIPTION
Getting vizlab landing page ready for water use release